### PR TITLE
Fix: Miniplayer Close Behavior

### DIFF
--- a/content.js
+++ b/content.js
@@ -630,6 +630,14 @@ function fixAudioTrack(settingsButton) {
 }
 
 function closeMenu() {
+  const miniplayer = document.querySelector(".ytp-miniplayer-ui")
+  const isMiniplayer = miniplayer.style['display'] != 'none';
+
+  if(isMiniplayer) {
+    miniplayer.click();
+    return null
+  }
+
   document.dispatchEvent(
     new KeyboardEvent("keydown", {
       key: "Escape",


### PR DESCRIPTION
Fixed an issue with the `closeMenu` function in the miniplayer. Previously, invoking `closeMenu` could inadvertently:
1. Close the video entirely.
2. Display a modal warning that the action would clear the queue.